### PR TITLE
Update Dockerfiles to Use Latest stable OS Versions

### DIFF
--- a/Dockerfiles/Dashboard+Coordinator/Dockerfile
+++ b/Dockerfiles/Dashboard+Coordinator/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 #installing pip and python
 RUN apt-get update -y && \

--- a/Dockerfiles/Worker/Dockerfile
+++ b/Dockerfiles/Worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04        
+FROM ubuntu:22.04      
 
 #Installing Python ClamAV
 RUN apt-get update -y && \

--- a/Dockerfiles/alpine/Dockerfile
+++ b/Dockerfiles/alpine/Dockerfile
@@ -1,5 +1,5 @@
 #base image alpine
-FROM alpine:3.10
+FROM alpine:3.21
 
 WORKDIR /home/flask
 

--- a/Dockerfiles/debian/Dockerfile
+++ b/Dockerfiles/debian/Dockerfile
@@ -1,5 +1,5 @@
 #base image ubuntu
-FROM debian:jessie
+FROM debian:stable-backports
 
 WORKDIR /home/flask
 

--- a/Dockerfiles/ubuntu/Dockerfile
+++ b/Dockerfiles/ubuntu/Dockerfile
@@ -1,5 +1,5 @@
 #base image ubuntu
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 WORKDIR /home/flask
 


### PR DESCRIPTION

This PR updates the following Dockerfiles to use the latest stable OS versions:  

- `Dockerfiles/Dashboard+Coordinator/Dockerfile`  
- `Dockerfiles/Worker/Dockerfile`  
- `Dockerfiles/alpine/Dockerfile`  
- `Dockerfiles/debian/Dockerfile`  
- `Dockerfiles/ubuntu/Dockerfile`  

### Changes:  
- Updated base OS versions to the latest stable releases.  
- Ensured compatibility and security improvements.  
- Verified that builds complete successfully with the new versions.  
